### PR TITLE
Add interactive Brand Guider prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# brandguider
-Tool to help brands build guidelines
+# Brand Guider
+
+Brand Guider is a minimalist web tool that helps brands assemble a complete set of
+visual guidelines. Pick typography, colours and logos while previewing changes in
+real time.
+
+## Features
+- **Typography** – choose from popular Google Fonts, adjust weights and heading styles.
+- **Colours** – pick primary and secondary colours to build your palette.
+- **Logos** – upload a logo and preview variations on different backgrounds.
+
+## Usage
+1. Open `index.html` in a modern web browser.
+2. Use the controls on the left to customise your brand settings.
+3. See updates instantly in the preview area and download/save as needed.
+
+## Development
+No build step is required. The project is fully static.
+
+To run a placeholder test script:
+```bash
+npm test
+```
+This will output a message indicating there are no tests yet.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Brand Guider</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
+</head>
+<body>
+  <div id="app">
+    <aside class="controls">
+      <h1>Brand Guider</h1>
+      <section>
+        <h2>Typography</h2>
+        <label>Font
+          <select id="fontSelect"></select>
+        </label>
+        <label>Weight
+          <input type="range" id="weightInput" min="100" max="900" step="100" value="400">
+        </label>
+        <div class="heading-style">
+          <p>Heading style</p>
+          <label><input type="radio" name="headingStyle" value="default" checked> Default</label>
+          <label><input type="radio" name="headingStyle" value="upper"> Uppercase</label>
+          <label><input type="radio" name="headingStyle" value="wide"> Wide</label>
+        </div>
+      </section>
+      <section>
+        <h2>Colours</h2>
+        <label>Primary
+          <input type="color" id="primaryColor" value="#0066ff">
+        </label>
+        <label>Secondary
+          <input type="color" id="secondaryColor" value="#ff6600">
+        </label>
+      </section>
+      <section>
+        <h2>Logo</h2>
+        <input type="file" id="logoInput" accept="image/*">
+      </section>
+    </aside>
+    <main class="preview">
+      <img id="logoPreview" class="logo" alt="Logo preview">
+      <div class="logo-variations">
+        <div class="primary"><img id="logoPrimary" alt="Primary logo variation"></div>
+        <div class="secondary"><img id="logoSecondary" alt="Secondary logo variation"></div>
+      </div>
+      <h1 contenteditable="true">Heading 1</h1>
+      <h2 contenteditable="true">Heading 2</h2>
+      <p contenteditable="true">Sample paragraph text to preview your selections. Edit this text to try different content.</p>
+    </main>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "brandguider",
+  "version": "1.0.0",
+  "description": "Tool to help brands build guidelines",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,62 @@
+const fonts = [
+  'Roboto',
+  'Open Sans',
+  'Lato',
+  'Montserrat',
+  'Oswald',
+  'Raleway',
+  'Poppins',
+  'Source Sans Pro'
+];
+
+function populateFonts() {
+  const select = document.getElementById('fontSelect');
+  fonts.forEach(font => {
+    const option = document.createElement('option');
+    option.value = font;
+    option.textContent = font;
+    select.appendChild(option);
+  });
+  updateFont(select.value);
+}
+
+function updateFont(font) {
+  WebFont.load({
+    google: { families: [font] },
+    active: () => {
+      document.documentElement.style.setProperty('--font-family', `'${font}', sans-serif`);
+    }
+  });
+}
+
+document.getElementById('fontSelect').addEventListener('change', e => updateFont(e.target.value));
+
+document.getElementById('weightInput').addEventListener('input', e => {
+  document.documentElement.style.setProperty('--font-weight', e.target.value);
+});
+
+document.getElementById('primaryColor').addEventListener('input', e => {
+  document.documentElement.style.setProperty('--primary-color', e.target.value);
+});
+
+document.getElementById('secondaryColor').addEventListener('input', e => {
+  document.documentElement.style.setProperty('--secondary-color', e.target.value);
+});
+
+document.getElementById('logoInput').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const url = URL.createObjectURL(file);
+  const preview = document.getElementById('logoPreview');
+  preview.src = url;
+  document.getElementById('logoPrimary').src = url;
+  document.getElementById('logoSecondary').src = url;
+});
+
+document.querySelectorAll('input[name="headingStyle"]').forEach(radio => {
+  radio.addEventListener('change', e => {
+    document.documentElement.setAttribute('data-heading', e.target.value);
+  });
+});
+
+populateFonts();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,109 @@
+:root {
+  --font-family: 'Roboto', sans-serif;
+  --font-weight: 400;
+  --primary-color: #0066ff;
+  --secondary-color: #ff6600;
+}
+
+body, html {
+  margin: 0;
+  height: 100%;
+  font-family: var(--font-family);
+  font-weight: var(--font-weight);
+  background: #f5f5f5;
+  color: #333;
+}
+
+#app {
+  display: flex;
+  height: 100vh;
+}
+
+.controls {
+  width: 300px;
+  padding: 1rem;
+  background: #fff;
+  overflow-y: auto;
+  border-right: 1px solid #ddd;
+}
+
+.controls h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.controls section {
+  margin-bottom: 1.5rem;
+}
+
+.controls label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.controls input,
+.controls select {
+  width: 100%;
+  padding: 0.25rem;
+  margin-top: 0.25rem;
+}
+
+.preview {
+  flex: 1;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  overflow-y: auto;
+}
+
+.preview .logo {
+  max-width: 150px;
+  margin-bottom: 2rem;
+}
+
+.logo-variations {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.logo-variations div {
+  width: 100px;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #ccc;
+}
+
+.logo-variations .primary {
+  background: var(--primary-color);
+}
+
+.logo-variations .secondary {
+  background: var(--secondary-color);
+}
+
+.logo-variations img {
+  max-width: 80%;
+  max-height: 80%;
+}
+
+[data-heading='upper'] h1,
+[data-heading='upper'] h2 {
+  text-transform: uppercase;
+}
+
+[data-heading='wide'] h1,
+[data-heading='wide'] h2 {
+  letter-spacing: 0.1em;
+}
+
+.preview h1 {
+  color: var(--primary-color);
+}
+
+.preview h2 {
+  color: var(--secondary-color);
+}


### PR DESCRIPTION
## Summary
- build static Brand Guider interface with controls for typography, colours and logos
- implement dynamic preview updating fonts, weights, colours and logo variations
- document usage and add placeholder test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68985fb6d6308321ad4a315642b7967a